### PR TITLE
Remove Python 3.5 and 3.6 builds (cause who needs them anyway)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-- '3.5'
-- '3.6'
 - '3.7'
 cache: pip
 install:


### PR DESCRIPTION
closes #10 